### PR TITLE
Better fix to check if scope of Parent is Page_Controller

### DIFF
--- a/code/model/PageContentSlice.php
+++ b/code/model/PageContentSlice.php
@@ -73,8 +73,8 @@ class PageContentSlice_Controller extends PageSliceController
      */
     public function getTemplate()
     {
-        // Weird fix that appeared in SS 3.5.2
-        if (in_array($this->Parent()->class, array('CMSPageEditController', 'CMSPageSettingsController', 'CMSPageHistoryController'))) {
+        // catch situations where Parent is different in CMS
+        if (!$this->Parent() instanceof Page_Controller) {
             return null;
         }
 


### PR DESCRIPTION
If edited in CMS, the scope of Parent is not the actual SiteTree Parent but the CMS controller. This catches this problem.