### PR TITLE
Names spacing needed

### DIFF
--- a/_config/PageSlices.yml
+++ b/_config/PageSlices.yml
@@ -11,4 +11,4 @@ Broarm\Silverstripe\PageSlices\PageSlice:
     - RedirectorPage
     - VirtualPage
   extensions:
-    - VersionedDataObject
+    - Heyday\VersionedDataObjects\VersionedDataObject


### PR DESCRIPTION
Without namespacing for Heyday\VersionedDataObjects\VersionedDataObject build errors occur.